### PR TITLE
[BugFix] Fix await consistent bug for replica node

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,2 @@
-Oracle: Berkeley DB, Java Edition 7.5.16: 2021-02-02 07:01:32 UTC
+This is based on # Oracle: Berkeley DB, Java Edition 7.5.16: 2021-02-02 07:01:32 UTC
 
-This is Berkeley DB, Java Edition, version 7.5.16 from
-Oracle.  To view the release and installation documentation, load
-the distribution file docs/index.html into your web browser.

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.starrocks</groupId>
     <artifactId>starrocks-bdb-je</artifactId>
-    <version>7.5.16</version>
+    <version>7.5.17</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/sleepycat/je/dbi/EnvironmentImpl.java
+++ b/src/main/java/com/sleepycat/je/dbi/EnvironmentImpl.java
@@ -3711,4 +3711,9 @@ public class EnvironmentImpl implements EnvConfigObserver {
                 this, restoreRequired.toString());
         }
     }
+
+    // only used for RepImpl
+    public void setReplicaLatestVLSNSeq(long seq) {
+
+    }
 }

--- a/src/main/java/com/sleepycat/je/log/LogManager.java
+++ b/src/main/java/com/sleepycat/je/log/LogManager.java
@@ -568,6 +568,9 @@ public class LogManager {
                 vlsn = envImpl.assignVLSNs(params.entry);
             } else {
                 vlsn = params.repContext.getClientVLSN();
+                if (params.repContext.inReplicationStream()) {
+                    envImpl.setReplicaLatestVLSNSeq(vlsn.getSequence());
+                }
             }
         } else {
             vlsn = null;

--- a/src/main/java/com/sleepycat/je/rep/impl/RepImpl.java
+++ b/src/main/java/com/sleepycat/je/rep/impl/RepImpl.java
@@ -2300,4 +2300,9 @@ public class RepImpl
     public StreamAuthenticator getAuthenticator() {
         return authenticator;
     }
+
+    @Override
+    public void setReplicaLatestVLSNSeq(long seq) {
+        vlsnIndex.setReplicaLatestVLSNSeq(seq);
+    }
 }

--- a/src/main/java/com/sleepycat/je/rep/vlsn/VLSNIndex.java
+++ b/src/main/java/com/sleepycat/je/rep/vlsn/VLSNIndex.java
@@ -359,6 +359,11 @@ public class VLSNIndex {
     private AtomicLong nextVLSNCounter;
 
     /*
+     * For replica node to record the latest vlsn seq copied from master
+     */
+    private volatile long replicaLatestVLSNSeq = VLSN.NULL_VLSN_SEQUENCE;
+
+    /*
      * For storing the persistent version of the VLSNIndex. For keys > 0,
      * the key is the VLSN sequence number, data = VLSNBucket. Key = -1 has
      * a special data item, which is the VLSNRange.
@@ -456,6 +461,8 @@ public class VLSNIndex {
         } else {
             nextVLSNCounter = new AtomicLong(last.getSequence());
         }
+
+        replicaLatestVLSNSeq = VLSN.NULL_VLSN_SEQUENCE;
     }
 
     /**
@@ -475,6 +482,7 @@ public class VLSNIndex {
 
         putWaitVLSN = null;
         nextVLSNCounter = null;
+        replicaLatestVLSNSeq = VLSN.UNINITIALIZED_VLSN_SEQUENCE;
     }
 
     /*
@@ -486,7 +494,15 @@ public class VLSNIndex {
     }
 
     public long getLatestAllocatedVal() {
-        return nextVLSNCounter.get();
+        if (nextVLSNCounter != null) {
+            return nextVLSNCounter.get();
+        } else {
+            return replicaLatestVLSNSeq;
+        }
+    }
+
+    public void setReplicaLatestVLSNSeq(long seq) {
+        replicaLatestVLSNSeq = seq;
     }
 
     /*
@@ -2117,7 +2133,7 @@ public class VLSNIndex {
     public void awaitConsistency() {
 
         /* VLSNIndex is not initialized and in use yet, no need to wait. */
-        if (nextVLSNCounter == null) {
+        if (nextVLSNCounter == null && replicaLatestVLSNSeq == VLSN.NULL_VLSN_SEQUENCE) {
             return;
         }
 


### PR DESCRIPTION
Fix #1 
Use a variable (replicaLatestVLSNSeq) to record the latest vlsn copied from master node. And wait for the replicaLatestVLSNSeq appeared in the vlsnIndex before completing the checkpoint.