### PR TITLE
[BugFix] Fix await consistent bug for replica node

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@ limitations under the License.
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.starrocks</groupId>
     <artifactId>starrocks-bdb-je</artifactId>
-    <version>18.3.12</version>
+    <version>18.3.13</version>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/sleepycat/je/JEVersion.java
+++ b/src/main/java/com/sleepycat/je/JEVersion.java
@@ -31,7 +31,7 @@ public class JEVersion implements Comparable<JEVersion>, Serializable {
      * Release version.
      */
     public static final JEVersion CURRENT_VERSION =
-        new JEVersion(18, 3, 12, null);
+        new JEVersion(18, 3, 13, null);
 
     private final int majorNum;
     private final int minorNum;

--- a/src/main/java/com/sleepycat/je/dbi/EnvironmentImpl.java
+++ b/src/main/java/com/sleepycat/je/dbi/EnvironmentImpl.java
@@ -3956,4 +3956,9 @@ public class EnvironmentImpl implements EnvConfigObserver {
                 this, restoreRequired.toString());
         }
     }
+
+    // only used for RepImpl
+    public void setReplicaLatestVLSNSeq(long seq) {
+    
+    }
 }

--- a/src/main/java/com/sleepycat/je/log/LogManager.java
+++ b/src/main/java/com/sleepycat/je/log/LogManager.java
@@ -568,6 +568,9 @@ public class LogManager {
                 vlsn = envImpl.assignVLSNs(params.entry);
             } else {
                 vlsn = params.repContext.getClientVLSN();
+                if (params.repContext.inReplicationStream()) {
+                    envImpl.setReplicaLatestVLSNSeq(vlsn.getSequence());
+                }
             }
         } else {
             vlsn = null;

--- a/src/main/java/com/sleepycat/je/rep/impl/RepImpl.java
+++ b/src/main/java/com/sleepycat/je/rep/impl/RepImpl.java
@@ -2380,4 +2380,9 @@ public class RepImpl
     public StreamAuthenticator getAuthenticator() {
         return authenticator;
     }
+
+    @Override
+    public void setReplicaLatestVLSNSeq(long seq) {
+        vlsnIndex.setReplicaLatestVLSNSeq(seq);
+    }
 }


### PR DESCRIPTION
Fix #1 
Use a variable (replicaLatestVLSNSeq) to record the latest vlsn copied from master node. And wait for the replicaLatestVLSNSeq appeared in the vlsnIndex before completing the checkpoint.