### PR TITLE
[BugFix] Fix int overflow bug

### DIFF
--- a/src/main/java/com/sleepycat/je/utilint/LatencyPercentile.java
+++ b/src/main/java/com/sleepycat/je/utilint/LatencyPercentile.java
@@ -284,7 +284,7 @@ public class LatencyPercentile
 
         /* Record this latency. */
         final int bucket =
-            Math.min((int) latencyMillis, maxTrackedLatencyMillis);
+            Math.min(Math.max(0, (int) latencyMillis), maxTrackedLatencyMillis);
         values.histogram.incrementAndGet(bucket);
 
         /* Update the count last */


### PR DESCRIPTION
Converting from long to int may cause overflow, use Math.max(0, (int) latencyMillis) to make sure the result of the conversion is not less than 0.

Fixes
```
Caused by: java.lang.ArrayIndexOutOfBoundsException: Index -1716603227 out of bounds for length 1001
        at java.lang.invoke.VarHandle$1.apply(VarHandle.java:2011) ~[?:?]
        at java.lang.invoke.VarHandle$1.apply(VarHandle.java:2008) ~[?:?]
        at jdk.internal.util.Preconditions$1.apply(Preconditions.java:159) ~[?:?]
        at jdk.internal.util.Preconditions$1.apply(Preconditions.java:156) ~[?:?]
        at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:62) ~[?:?]
        at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
        at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248) ~[?:?]
        at java.lang.invoke.VarHandleLongs$Array.getAndAdd(VarHandleLongs.java:721) ~[?:?]
        at java.lang.invoke.VarHandleGuards.guard_LIJ_J(VarHandleGuards.java:778) ~[?:?]
        at java.util.concurrent.atomic.AtomicLongArray.incrementAndGet(AtomicLongArray.java:234) ~[?:?]
        at com.sleepycat.je.utilint.LatencyPercentile.add(LatencyPercentile.java:288) ~[starrocks-bdb-je-18.3.16.jar:?]
        at com.sleepycat.je.rep.impl.node.Feeder$InputThread.processHeartbeatResponse(Feeder.java:981) ~[starrocks-bdb-je-18.3.16.jar:?]
        at com.sleepycat.je.rep.impl.node.Feeder$InputThread.runResponseLoop(Feeder.java:856) ~[starrocks-bdb-je-18.3.16.jar:?]
        at com.sleepycat.je.rep.impl.node.Feeder$InputThread.run(Feeder.java:755) ~[starrocks-bdb-je-18.3.16.jar:?]

```