### PR TITLE
Fix Feeder handshake bug

### DIFF
--- a/src/main/java/com/sleepycat/je/rep/impl/node/Feeder.java
+++ b/src/main/java/com/sleepycat/je/rep/impl/node/Feeder.java
@@ -1755,7 +1755,7 @@ final public class Feeder {
     }
 
     /**
-     * Check the whether the channel is available by monitoring the change of lastHeartbeatTime,
+     * Check whether the channel is available by monitoring the change of lastHeartbeatTime,
      * the loop will break when:
      * 1. feeder is shutdown
      * 2. channel is not open
@@ -1770,7 +1770,7 @@ final public class Feeder {
 
         long baseTime = this.lastHeartbeatTime;
         long startNs = System.nanoTime();
-        long timeoutNs = repNode.getConfigManager().getDuration(RepParams.FEEDER_TIMEOUT) * 1000000;
+        long timeoutNs = repNode.getConfigManager().getDuration(RepParams.FEEDER_TIMEOUT) * 1000000L;
         while (System.nanoTime() - startNs < timeoutNs) {
             if (shutdown.get()
                     || !feederReplicaChannel.isOpen()) {

--- a/src/main/java/com/sleepycat/je/rep/impl/node/Feeder.java
+++ b/src/main/java/com/sleepycat/je/rep/impl/node/Feeder.java
@@ -1763,11 +1763,6 @@ final public class Feeder {
      * 4. FEEDER_TIMEOUT reached
      */
     public boolean isChannelAvailable() {
-        if (shutdown.get()
-                || !feederReplicaChannel.isOpen()) {
-            return false;
-        }
-
         long baseTime = this.lastHeartbeatTime;
         long startNs = System.nanoTime();
         long timeoutNs = repNode.getConfigManager().getDuration(RepParams.FEEDER_TIMEOUT) * 1000000L;

--- a/src/main/java/com/sleepycat/je/rep/impl/node/Feeder.java
+++ b/src/main/java/com/sleepycat/je/rep/impl/node/Feeder.java
@@ -1753,4 +1753,41 @@ final public class Feeder {
 
         throw new ReplicationSecurityException(err, replica, null);
     }
+
+    /**
+     * Check the whether the channel is available by monitoring the change of lastHeartbeatTime,
+     * the loop will break when:
+     * 1. feeder is shutdown
+     * 2. channel is not open
+     * 3. lastHeartbeatTime changed
+     * 4. FEEDER_TIMEOUT reached
+     */
+    public boolean isChannelAvailable() {
+        if (shutdown.get()
+                || !feederReplicaChannel.isOpen()) {
+            return false;
+        }
+
+        long baseTime = this.lastHeartbeatTime;
+        long startNs = System.nanoTime();
+        long timeoutNs = repNode.getConfigManager().getDuration(RepParams.FEEDER_TIMEOUT) * 1000000;
+        while (System.nanoTime() - startNs < timeoutNs) {
+            if (shutdown.get()
+                    || !feederReplicaChannel.isOpen()) {
+                return false;
+            }
+
+            if (baseTime != lastHeartbeatTime) {
+                return true;
+            }
+
+            try {
+                Thread.sleep(500L);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/com/sleepycat/je/rep/impl/node/Feeder.java
+++ b/src/main/java/com/sleepycat/je/rep/impl/node/Feeder.java
@@ -1777,7 +1777,7 @@ final public class Feeder {
                 return false;
             }
 
-            if (baseTime != lastHeartbeatTime) {
+            if (baseTime < lastHeartbeatTime) {
                 return true;
             }
 

--- a/src/main/java/com/sleepycat/je/rep/stream/FeederReplicaHandshake.java
+++ b/src/main/java/com/sleepycat/je/rep/stream/FeederReplicaHandshake.java
@@ -610,8 +610,8 @@ public class FeederReplicaHandshake {
          * channel is still open, if it is already closed, then we will
          * issue a shutdown to the feeder explicitly.
          */
-        if (dup != null && dup.getChannel() != null &&
-            !dup.getChannel().isOpen() && !dup.isShutdown()) {
+        if (dup != null && dup.getChannel() != null
+                && !dup.isChannelAvailable()) {
             dup.shutdown(new IOException("Feeder's channel for node " +
                                          replicaNameIdPair +
                                          " is already closed"));


### PR DESCRIPTION
Fix 
```
A replica with the name: xxx is already active with the Feeder:null HANDSHAKE_ERROR: Error during the handshake between two nodes. xxxxxx
        at com.sleepycat.je.rep.stream.ReplicaFeederHandshake.negotiateProtocol(ReplicaFeederHandshake.java:198)
        at com.sleepycat.je.rep.stream.ReplicaFeederHandshake.execute(ReplicaFeederHandshake.java:250)
        at com.sleepycat.je.rep.impl.node.Replica.initReplicaLoop(Replica.java:710)
        at com.sleepycat.je.rep.impl.node.Replica.runReplicaLoopInternal(Replica.java:486)
        at com.sleepycat.je.rep.impl.node.Replica.runReplicaLoop(Replica.java:413)
        at com.sleepycat.je.rep.impl.node.RepNode.run(RepNode.java:1871)
```

If the leader is blocked for 30 seconds (heartbeat timeout), the follower will trigger an election, but the old leader will be re-elected with a high probability. In this case, the follower will close the old replica-feeder connection and open a new replica-feeder connection to the same leader. But if the old connection is still not deleted during the new link handshake, it will report a duplicate connection error.

The `dup.getChannel().isOpen()` is not enough to judge the availability of the connection, we should check whether there is heartbeat in the old connection.